### PR TITLE
Add `number_with_delimiter` to long counters

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,4 +32,8 @@ module ApplicationHelper
     title = title.starts_with?('Rails Contributors') ? title : "Rails Contributors - #{title}"
     strip_tags(title)
   end
+
+  def pluralize_with_delimiter(count, singular, plural = nil)
+    pluralize number_with_delimiter(count), singular, plural
+  end
 end

--- a/app/views/commits/index.html.erb
+++ b/app/views/commits/index.html.erb
@@ -22,7 +22,7 @@
 <div class="vcard">
   <h1 id="title">
     <%= @title %><br/>
-    <span class="listing-total">Showing <%= pluralize @commits.size, 'commit' %></span>
+    <span class="listing-total">Showing <%= pluralize_with_delimiter @commits.size, 'commit' %></span>
   </h1>
 
   <div id="table-wrap">

--- a/app/views/contributors/_contributor.html.erb
+++ b/app/views/contributors/_contributor.html.erb
@@ -12,6 +12,6 @@
          contributor_commits_path(contributor)
        end
     %>
-    <%= link_to contributor.ncommits, path %>
+    <%= link_to number_with_delimiter(contributor.ncommits), path %>
   </td>
 </tr>

--- a/app/views/contributors/index.html.erb
+++ b/app/views/contributors/index.html.erb
@@ -5,7 +5,7 @@
 
 <h1 id="title">
   <%= @title %><br/>
-  <span class="listing-total">Showing <%= pluralize @contributors.length, 'person' %></span>
+  <span class="listing-total">Showing <%= pluralize_with_delimiter @contributors.length, 'person' %></span>
 </h1>
 <%= link_to "See names mapping →", 'https://github.com/fxn/rails-contributors/blob/master/app/models/names_manager.rb', class: 'name-mapping' %>
 

--- a/app/views/releases/index.html.erb
+++ b/app/views/releases/index.html.erb
@@ -8,7 +8,7 @@
 <div class="vcard">
   <h1 id="title">
     <%= @title %><br/>
-    <span class="listing-total">Showing <%= pluralize @releases.size, 'releases' %></span>
+    <span class="listing-total">Showing <%= pluralize_with_delimiter @releases.size, 'releases' %></span>
   </h1>
 
   <div id="table-wrap">


### PR DESCRIPTION
Makes long counters easy to read:

![commits](https://cloud.githubusercontent.com/assets/10076/5302395/cc1008c0-7b94-11e4-9bf3-9959a763895b.png)
![commit](https://cloud.githubusercontent.com/assets/10076/5302396/cc134382-7b94-11e4-844c-ae24ca630f37.png)
![releases](https://cloud.githubusercontent.com/assets/10076/5302398/cc15434e-7b94-11e4-97c2-c1d9ac4cb459.png)
![contributors](https://cloud.githubusercontent.com/assets/10076/5302397/cc14d27e-7b94-11e4-9ad6-e515996f896c.png)

@fxn What do you think?
