### PR TITLE
Show a weeks contributions from a given iso8601 date.

### DIFF
--- a/app/controllers/commits_controller.rb
+++ b/app/controllers/commits_controller.rb
@@ -1,8 +1,8 @@
 class CommitsController < ApplicationController
-  caches_page :index, :in_time_window, :in_release, :in_edge
+  caches_page :index, :in_time_window, :in_week, :in_release, :in_edge
 
   before_action :set_target, only: %w(index in_release)
-  before_action :set_contributor, only: %w(in_edge in_time_window)
+  before_action :set_contributor, only: %w(in_edge in_time_window in_week)
   before_action :set_time_constraints, only: 'in_time_window'
 
   def index
@@ -13,6 +13,12 @@ class CommitsController < ApplicationController
     commits = @contributor.commits
     commits = commits.since(@since) if @since
     @commits = commits.sorted
+    render 'index'
+  end
+
+  def in_week
+    @week_start = Date.iso8601(params[:date]).beginning_of_week
+    @commits = @contributor.commits.in_week_of(@week_start).sorted
     render 'index'
   end
 

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -1,5 +1,5 @@
 class ContributorsController < ApplicationController
-  caches_page :index, :in_time_window, :in_edge
+  caches_page :index, :in_time_window, :in_week, :in_edge
 
   def index
     @contributors = if params[:release_id].present?
@@ -18,6 +18,13 @@ class ContributorsController < ApplicationController
     else
       Contributor.all_with_ncommits
     end
+
+    render 'index'
+  end
+
+  def in_week
+    @week_start = Date.iso8601(params[:date]).beginning_of_week
+    @contributors = Contributor.all_with_ncommits_in_week_of(@week_start)
 
     render 'index'
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,6 +21,10 @@ module ApplicationHelper
     "#{title} - #{TimeConstraints.label_for(time_window)}".html_safe
   end
 
+  def add_week_to(title, week_start)
+    "#{title} - #{week_start.cweek.ordinalize} week #{week_start.cwyear}".html_safe
+  end
+
   def sidebar_tab(name, current, options={}, html_options={})
     li_options = current ? {class: 'current'} : {}
     content_tag :li, li_options do

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -13,6 +13,10 @@ class Commit < ActiveRecord::Base
     where(['commits.committer_date >= ?', date])
   }
 
+  scope :in_week_of, ->(date) {
+    where('commits.committer_date' => date.all_week)
+  }
+
   scope :release, ->(release) {
     where('commits.release_id' => release.id)
   }

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -20,6 +20,10 @@ class Contributor < ActiveRecord::Base
     _all_with_ncommits(:commits, ['commits.committer_date > ?', date])
   end
 
+  def self.all_with_ncommits_in_week_of(date)
+    _all_with_ncommits(:commits, 'commits.committer_date' => date.all_week)
+  end
+
   def self.all_with_ncommits_by_release(release)
     _all_with_ncommits(:commits, 'commits.release_id' => release.id)
   end

--- a/app/views/commits/index.html.erb
+++ b/app/views/commits/index.html.erb
@@ -7,6 +7,10 @@
     @title       = %(##{@contributor.rank} <span class="fn">#{h(@contributor.name)}</span> - Edge).html_safe
     @description = "Unreleased commits contributed by #{@contributor.name} to Ruby on Rails"
     @keywords    = @contributor.name
+  elsif @contributor && @week_start
+    @title       = add_week_to(%(##{@contributor.rank} <span class="fn">#{h(@contributor.name)}</span>), @week_start)
+    @description = "Commits contributed by #{@contributor.name} in week starting #{@week_start.to_s(:rfc822)}"
+    @keywords    = @contributor.name
   elsif @contributor
     @title       = add_window_to(%(##{@contributor.rank} <span class="fn">#{h(@contributor.name)}</span>), @time_window)
     @description = "Commits contributed by #{@contributor.name} to Ruby on Rails"

--- a/app/views/contributors/_contributor.html.erb
+++ b/app/views/contributors/_contributor.html.erb
@@ -4,6 +4,8 @@
   <td class="no-commits">
     <% path = if @time_window
          contributor_commits_in_time_window_path(contributor, @time_window)
+       elsif @week_start
+         contributor_commits_in_week_path(contributor, @week_start.iso8601)
        elsif @release
          contributor_commits_in_release_path(contributor, @release)
        elsif @edge

--- a/app/views/contributors/index.html.erb
+++ b/app/views/contributors/index.html.erb
@@ -1,5 +1,13 @@
 <%
-   @title = @release ? "Rails Contributors - #{@release.name}" : @edge ? 'Rails Contributors - Edge' : add_window_to("Rails Contributors", @time_window)
+   @title = if @release
+      "Rails Contributors - #{@release.name}"
+    elsif @edge
+      'Rails Contributors - Edge'
+    elsif @week_start
+      add_week_to("Contributors", @week_start)
+    else
+      add_window_to("Rails Contributors", @time_window)
+    end
    @description = 'Ruby on Rails contributors'
 %>
 

--- a/app/views/shared/_window_sidebar.html.erb
+++ b/app/views/shared/_window_sidebar.html.erb
@@ -7,7 +7,7 @@
     <% for key, name in TimeConstraints.all %>
       <% path = key == 'all-time' ? contributors_path : contributors_in_time_window_path(key) %>
       <%# TODO: clean this %>
-      <%= sidebar_tab name, in_time_window && ((@time_window.nil? && key == 'all-time') || @time_window == key), path %>
+      <%= sidebar_tab name, !@week_start && in_time_window && ((@time_window.nil? && key == 'all-time') || @time_window == key), path %>
     <% end %>
     <%= sidebar_tab 'Releases', in_release, releases_path %>
     <%= sidebar_tab 'Edge', in_edge, contributors_in_edge_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,10 @@
 RailsContributors::Application.routes.draw do
   get 'contributors/in-time-window/:time_window' => 'contributors#in_time_window', as: 'contributors_in_time_window'
+  get 'contributors/in-week-of/:date' => 'contributors#in_week', as: 'contributors_in_week', date: /\d{4}-\d{2}-\d{2}/
 
   resources :contributors, only: 'index' do
     get 'commits/in-time-window/:time_window' => 'commits#in_time_window', as: 'commits_in_time_window'
+    get 'commits/in-week-of/:date'            => 'commits#in_week',        as: 'commits_in_week', date: /\d{4}-\d{2}-\d{2}/
     get 'commits/in-release/:release_id'      => 'commits#in_release',     as: 'commits_in_release'
     get 'commits/in-edge'                     => 'commits#in_edge',        as: 'commits_in_edge'
 

--- a/test/controllers/commits_controller_test.rb
+++ b/test/controllers/commits_controller_test.rb
@@ -79,6 +79,16 @@ class CommitsControllerTest < ActionController::TestCase
     end
   end
 
+  def test_in_week
+    get :in_week, contributor_id: contributors(:jose), date: '2012-01-19'
+
+    assert_response :success
+    assert_equal [commits(:commit_5b90635)], assigns(:commits)
+
+    assert_select 'span.listing-total', 'Showing 1 commit'
+    assert_select '.vcard #title', /3rd week 2012/
+  end
+
   def test_in_release
     cases = {
       contributors(:jeremy) => {releases('v3_2_0') => [commits(:commit_5b90635)],

--- a/test/controllers/contributors_controller_test.rb
+++ b/test/controllers/contributors_controller_test.rb
@@ -69,6 +69,22 @@ class ContributorsControllerTest < ActionController::TestCase
     end
   end
 
+  def test_in_week
+    expected = [[:jeremy, 1], [:jose, 1], [:vijay, 1]]
+
+    get :in_week, date: '2012-01-19'
+
+    assert_response :success
+
+    actual = assigns(:contributors)
+    assert_equal expected.size, actual.size
+
+    expected.zip(actual).each do |e, a|
+      assert_equal contributors(e.first).name, a.name
+      assert_equal e.second, a.ncommits
+    end
+  end
+
   def test_in_edge
     # Order by ncommits DESC, url_id ASC.
     expected = [[:jeremy, 2], [:david, 1], [:xavier, 1]]


### PR DESCRIPTION
Hi Xavier!

On Fridays we send our weekly [This Week in Rails newsletter](http://rails-weekly.ongoodbits.io) and link to the top contributors.

Come Monday that link breaks because `contributors/in-time-window/this-week` has already moved on. We, however, are a bit more nostalgic and would like a canonical reference to a given week.

We also don't know when weeks begin and end - all I see anymore is newsletter Fridays. Ideally we'd like to input a date and have the app figure out which week it's part of.

I've added this feature including date range ballooning. Then by linking to `contributors/in-week-of/2015-02-13` the coming Friday 13th we can really scare our readers :hocho:

cc @chancancode