### PR TITLE
Count contribution toward committers too.

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -81,6 +81,10 @@ protected
     message.include?('git-svn-id: http://svn-commit.rubyonrails.org/rails')
   end
 
+  def committed_by_author?
+    author_name == committer_name
+  end
+
   # Both svn and git may have the name of the author in the message using the [...]
   # convention. If none is found we check the changelog entry for svn commits.
   # If that fails as well the contributor is the git author by definition.
@@ -100,6 +104,8 @@ protected
         end
       end
     end
+
+    names << committer_name unless committed_by_author?
 
     # In modern times we are counting merge commits, because behind a merge
     # commit there is work by the core team member in the pull request. To

--- a/test/models/repo_test.rb
+++ b/test/models/repo_test.rb
@@ -1,6 +1,14 @@
 require 'test_helper'
 
 class RepoTest < ActiveSupport::TestCase
+  def test_gives_contribution_to_committer_not_matching_author
+    Contribution.destroy_all
+    contributor_names = Repo.new.send(:compute_contributor_names_per_commit)
+
+    assert_equal [ 'Jeremy Daer', 'Toshinori Kajihara' ],
+      contributor_names[commits(:commit_7cdfd91).sha1]
+  end
+
   def test_sync_ranks
     Repo.new.send(:sync_ranks)
 


### PR DESCRIPTION
If a commit was written by an author but committed by someone else,
the contributors app currently generates no contribution for the committer.

Which is not what we want because the committer is one from the
Rails team who won't have a due contribution counted their way.

These cases happen if the committer manually squashes a PR, for instance,
through GitHubs squash commits merge button.

Fix by appending the committer name in those cases.

@rafaelfranca you've asked for this in the past.

Here's an example of a commit that should count toward the committer: https://github.com/rails/rails/commit/cacded5a0e0acc0582c2778b9dd8df684451ad53 (in that case, me 😁).