### PR TITLE
add listen gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'coffee-rails', '~> 4.2.1'
 
 group :development do
   gem 'byebug'
+  gem 'listen'
   gem 'web-console', '~> 2.0'
   gem 'spring'
   gem 'capistrano', '~> 3.4',         require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,9 +86,14 @@ GEM
       chronic
     erubis (2.7.0)
     execjs (2.7.0)
+    ffi (1.9.18)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -138,6 +143,10 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
+    rb-fsevent (0.9.8)
+    rb-inotify (0.9.8)
+      ffi (>= 0.5.0)
+    ruby_dep (1.5.0)
     rugged (0.21.0)
     sass (3.4.22)
     sass-rails (5.0.6)
@@ -192,6 +201,7 @@ DEPENDENCIES
   capistrano3-puma (~> 1.0)
   coffee-rails (~> 4.2.1)
   delorean
+  listen
   pg
   puma
   rails (~> 5.0.0)
@@ -208,4 +218,4 @@ RUBY VERSION
    ruby 2.2.5p319
 
 BUNDLED WITH
-   1.13.6
+   1.14.6


### PR DESCRIPTION
Prior to adding the `listen` gem, I received the following when running `bin/setup`:

```
Bundled gems are installed into ./.bundle.
Created database 'rails_contributors_development'
Created database 'rails_contributors_test'
rails aborted!
LoadError: Could not load the 'listen' gem. Add `gem 'listen'` to the development group of your Gemfile

...

/Projects/rails-contributors/bin/rails:8:in `require'
/Projects/rails-contributors/bin/rails:8:in `<top (required)>'
/Projects/rails-contributors/.bundle/gems/spring-2.0.0/lib/spring/client/rails.rb:28:in `load'
/Projects/rails-contributors/.bundle/gems/spring-2.0.0/lib/spring/client/rails.rb:28:in `call'
/Projects/rails-contributors/.bundle/gems/spring-2.0.0/lib/spring/client/command.rb:7:in `call'
/Projects/rails-contributors/.bundle/gems/spring-2.0.0/lib/spring/client.rb:30:in `run'
/Projects/rails-contributors/.bundle/gems/spring-2.0.0/bin/spring:49:in `<top (required)>'
/Projects/rails-contributors/.bundle/gems/spring-2.0.0/lib/spring/binstub.rb:31:in `load'
/Projects/rails-contributors/.bundle/gems/spring-2.0.0/lib/spring/binstub.rb:31:in `<top (required)>'
/Projects/rails-contributors/bin/spring:16:in `require'
/Projects/rails-contributors/bin/spring:16:in `<top (required)>'
bin/rails:3:in `load'
bin/rails:3:in `<main>'
Tasks: TOP => db:schema:load => environment
(See full trace by running task with --trace)
```

I truncated the full trace, but you can see that Spring 2.0.0 appears to need the `listen` gem.