### PR TITLE
add instructions for database population

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ After this you can use the Rails rake tasks:
 bin/rails test
 ```
 
+## Developing locally
+
+To populate an empty database:
+
+```
+bundle exec rails runner Repo.sync
+```
+
+To repopulate the database based on code changes:
+
+```
+bundle exec rails runner "Repo.sync(rebuild_all: true)"
+```
+
 ## License
 
 Released under the MIT License, Copyright (c) 2012–<i>ω</i> Xavier Noria.


### PR DESCRIPTION
While testing my mapping change, I wanted to confirm I was making the change properly. I found `Repo.sync` and it's comments helpful and thought others might want an easier place to find it.