### PR TITLE
Maps "Marc Ignacio" to "Marc Rendl Ignacio"

### DIFF
--- a/app/models/names_manager/canonical_names.rb
+++ b/app/models/names_manager/canonical_names.rb
@@ -713,6 +713,7 @@ module NamesManager
     map 'Manuel Holtgrewe',           "purestorm\100ggnore.net"
     map 'Marc Huffnagle',             'mhuffnagle'
     map 'Marc Love',                  'marclove'
+    map 'Marc Rendl Ignacio',         'Marc Ignacio'
     map 'Marc-André Cournoyer',       'macournoyer'
     map 'Marc-André Lafortune',       'Marc-Andre Lafortune'
     map 'Marcel Molina Jr.',          'Marcel Molina', 'Marcel', 'Marcel Molina Jr', 'marcel', 'noradio', 'Marcel Mollina Jr.'

--- a/test/credits/canonical_names_test.rb
+++ b/test/credits/canonical_names_test.rb
@@ -3387,6 +3387,11 @@ module Credits
       assert_contributor_names 'f005587', 'Jeffrey Hardy'
     end
 
+    test 'padi' do
+      assert_contributor_names '927e986', 'Marc Rendl Ignacio'
+      assert_contributor_names 'f55ecc6', 'Marc Rendl Ignacio'
+    end
+
     test 'pager' do
       assert_contributor_names '6a611e1', 'Dmitriy Timokhin'
     end

--- a/test/credits/canonical_names_test.rb
+++ b/test/credits/canonical_names_test.rb
@@ -3388,7 +3388,6 @@ module Credits
     end
 
     test 'padi' do
-      assert_contributor_names '927e986', 'Marc Rendl Ignacio'
       assert_contributor_names 'f55ecc6', 'Marc Rendl Ignacio'
     end
 


### PR DESCRIPTION
I've recently made rails/rails commits that split my contribution count across multiple rows in http://contributors.rubyonrails.org/contributors. This resolves that. 

@fxn let me know if I need to do other changes. I've checked the 'Allow edits from maintainers' if it's a no brainer. Cheers! 🥂 