### PR TITLE
Kazuhiko is not Kazuhiro

### DIFF
--- a/app/models/names_manager/canonical_names.rb
+++ b/app/models/names_manager/canonical_names.rb
@@ -632,7 +632,8 @@ module NamesManager
     map 'Karol Bucek',                'kares'
     map 'Kaspar Schiess',             "eule\100space.ch"
     map 'Kasper Timm Hansen',         'Timm'
-    map 'Kazuhiro Yoshida',           "moriq\100moriq.com", 'moriq', "kazuhiko\100fdiary.net"
+    map 'Kazuhiko Shiozaki',          "kazuhiko\100fdiary.net", 'Kazuhiko'
+    map 'Kazuhiro Yoshida',           "moriq\100moriq.com", 'moriq'
     map 'Keegan Quinn',               "keegan\100thebasement.org"
     map 'Kei Shiratsuchi',            'kei'
     map 'Keith Gautreaux',            'kaygee', 'kgautreaux'

--- a/test/credits/canonical_names_test.rb
+++ b/test/credits/canonical_names_test.rb
@@ -2384,7 +2384,7 @@ module Credits
     end
 
     test "kazuhiko\100fdiary.net" do
-      assert_contributor_names '3c8dbcb', 'Kazuhiro Yoshida'
+      assert_contributor_names '8e78e93', 'Kazuhiko Shiozaki'
     end
 
     test 'KD' do


### PR DESCRIPTION
CanonicalNames maps "kazuhiko@fdiary.net" to Kazuhiro since c94d9d7bf8b75d24f158176bfd8e9e9b30093b04, but Kazuhiko and Kazuhiro are different individuals (I've met both of them).